### PR TITLE
Add netstandard2.0 target framework

### DIFF
--- a/src/DiffPatch/DiffPatch.csproj
+++ b/src/DiffPatch/DiffPatch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>DiffPatch</PackageId>
     <PackageVersion>1.0.1</PackageVersion>
     <Authors>Amael BERTEAU</Authors>


### PR DESCRIPTION
Hi,

I'd like to consume this library from a .NET Framework 4.7.2 project. At the moment, when I reference the current netstandard1.3 version of DiffPatch, it also adds a lot (+-40) of other .NET Standard libraries, which I'd like to avoid. I also get some binding redirect issues (probably due to other libraries that I'm also referencing) 

Building DiffPatch against netstandard2.0 solves that issue as .NET Framework 4.7.2 fully implements netstandard2.0. Would you please accept this PR and add the additional build to the NuGet package?