### PR TITLE
Automatically generate .nupkg upon Release build

### DIFF
--- a/src/DiffPatch/DiffPatch.csproj
+++ b/src/DiffPatch/DiffPatch.csproj
@@ -9,7 +9,18 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>First release</PackageReleaseNotes>
     <Copyright>Copyright 2017 (c) Amael BERTEAU. All rights reserved.</Copyright>
+    <Copyright>MIT</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/aberteau/DiffPatch</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageTags>diff patch</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Optimize>true</Optimize>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Just a PR that may help a bit. Autogenerates the NuGet package (including more info, e.g. repo URL) and symbols package.