### PR TITLE
Updating target framework (netstandard1.3 -> netstandard2.0)

### DIFF
--- a/src/DiffPatch.Tests/DiffPatch.Tests.csproj
+++ b/src/DiffPatch.Tests/DiffPatch.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/DiffPatch/DiffPatch.csproj
+++ b/src/DiffPatch/DiffPatch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>DiffPatch</PackageId>
     <PackageVersion>1.0.1</PackageVersion>
     <Authors>Amael BERTEAU</Authors>
@@ -10,6 +10,7 @@
     <PackageReleaseNotes>First release</PackageReleaseNotes>
     <Copyright>Copyright 2017 (c) Amael BERTEAU. All rights reserved.</Copyright>
     <PackageTags>diff patch</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Following the request of igitur (see https://github.com/aberteau/DiffPatch/pull/2#issue-477772035) and since net standard 2.0 is widespread, I decided to switch to "net standard 2.0" as target framework.